### PR TITLE
ExchangeDeclaredException commented because prevents several channels usage

### DIFF
--- a/src/QueueProvider.php
+++ b/src/QueueProvider.php
@@ -69,9 +69,9 @@ final class QueueProvider implements QueueProviderInterface
             return $this;
         }
 
-        if ($this->exchangeSettings !== null) {
-            throw new ExchangeDeclaredException();
-        }
+        //if ($this->exchangeSettings !== null) {
+        //    throw new ExchangeDeclaredException();
+        //}
 
         $instance = clone $this;
         $instance->channel = null;


### PR DESCRIPTION
ExchangeDeclaredException commented because prevents several channels usage

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️

I'm trying to use several channels pushing messages this way

```php
use Yiisoft\Queue as YiiQueue;

class Queue
{
    public static function get(string $channel = YiiQueue\QueueInterface::DEFAULT_CHANNEL): YiiQueue\QueueInterface
    {
        $di = DI\ServiceLocator::getInstance();

        $adapter = $di->get(YiiQueue\Adapter\AdapterInterface::class)
            ->withChannel($channel);
        $queue = $di->get(YiiQueue\Queue::class);

        return $queue->withAdapter($adapter);
    }
}

Queue::get('{custom-channel-name}')->push(/* message */);
```
Everything is ok here, message successufully pushed to new queue of RabbitMQ.

But when trying to use build-in commands, like `listen {custom-channel-name}` get `ExchangeDeclaredException()`.
As I discovered while researching the source code problem occurs on line 84 of `src/QueueProvider.php` because `$this->exchangeSettings` never equals to null because of default value in `__construct()`.

Used this as hard-fix only