### PR TITLE
Optimize message publishing

### DIFF
--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -11,7 +11,6 @@ use Yiisoft\Queue\Adapter\AdapterInterface;
 use Yiisoft\Queue\AMQP\Exception\NotImplementedException;
 use Yiisoft\Queue\Cli\LoopInterface;
 use Yiisoft\Queue\JobStatus;
-use Yiisoft\Queue\Message\IdEnvelope;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Message\MessageSerializerInterface;
 

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -58,7 +58,7 @@ final class Adapter implements AdapterInterface
 
     public function push(MessageInterface $message): MessageInterface
     {
-        $this->amqpMessage = $this->amqpMessage ?? new AMQPMessage(
+        $this->amqpMessage ??= new AMQPMessage(
             '',
             $this->queueProvider->getMessageProperties(),
         );

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -59,10 +59,6 @@ final class Adapter implements AdapterInterface
 
     public function push(MessageInterface $message): MessageInterface
     {
-        if (empty($message->getMetadata()[IdEnvelope::MESSAGE_ID_KEY])) {
-            $message = new IdEnvelope($message, uniqid(more_entropy: true));
-        }
-
         $this->amqpMessage = $this->amqpMessage ?? new AMQPMessage(
             '',
             $this->queueProvider->getMessageProperties(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #58 

Message ID creation is moved to https://github.com/yiisoft/queue/pull/245

Benchmark results when running locally:
![image](https://github.com/user-attachments/assets/779e25d8-e382-43ec-899b-566d5c16edd2)
