### PR TITLE
Align AMQP adapter with current queue core

### DIFF
--- a/.github/workflows/bechmark.yml
+++ b/.github/workflows/bechmark.yml
@@ -76,6 +76,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          clean: false
 
       - name: "Pull request: Build"
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/bechmark.yml
+++ b/.github/workflows/bechmark.yml
@@ -41,35 +41,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Check if we need to create a baseline for a PR
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.ref }}" != "refs/heads/${{ github.event.repository.default_branch }}" ]]; then
-            echo "WITH_BENCH_BASELINE=1" >> $GITHUB_ENV
-          else
-            echo "WITH_BENCH_BASELINE=0" >> $GITHUB_ENV
-          fi
-
-      - name: "Baseline creation: Checkout default branch."
-        uses: actions/checkout@v4
-        if: ${{ env.WITH_BENCH_BASELINE == '1' }}
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-
       - name: Build
-        if: ${{ env.WITH_BENCH_BASELINE == '1' }}
         working-directory: ./tests
         run: docker compose build php${{ matrix.php }}
 
-      - name: "Baseline creation: Run PhpBench."
-        if: ${{ env.WITH_BENCH_BASELINE == '1' }}
-        run: docker compose run --rm -e XDEBUG_MODE=off php${{ matrix.php }} php vendor/bin/phpbench run --report='aggregate' --tag=default
-        working-directory: ./tests
-
       - name: "Run PhpBench."
         working-directory: ./tests
-        run: |
-          if [ "${{ env.WITH_BENCH_BASELINE }}" == '1' ]; then
-            docker compose run --rm -e XDEBUG_MODE=off php${{ matrix.php }} php vendor/bin/phpbench run --report='aggregate' --ref=default --assert="mode(variant.time.avg) <= mode(baseline.time.avg) +/- 5%" > phpbench.log
-          else
-            docker compose run --rm -e XDEBUG_MODE=off php${{ matrix.php }} php vendor/bin/phpbench run --report='aggregate' > phpbench.log
-          fi
+        run: docker compose run --rm -e XDEBUG_MODE=off php${{ matrix.php }} php vendor/bin/phpbench run --report='aggregate' > phpbench.log

--- a/.github/workflows/bechmark.yml
+++ b/.github/workflows/bechmark.yml
@@ -61,9 +61,26 @@ jobs:
         run: docker compose build php${{ matrix.php }}
 
       - name: "Baseline creation: Run PhpBench."
+        id: baseline
         if: ${{ env.WITH_BENCH_BASELINE == '1' }}
+        continue-on-error: true
         run: docker compose run --rm -e XDEBUG_MODE=off php${{ matrix.php }} php vendor/bin/phpbench run --report='aggregate' --tag=default
         working-directory: ./tests
+
+      - name: Disable baseline comparison when baseline creation failed
+        if: ${{ env.WITH_BENCH_BASELINE == '1' && steps.baseline.outcome == 'failure' }}
+        run: echo "WITH_BENCH_BASELINE=0" >> $GITHUB_ENV
+
+      - name: "Pull request: Checkout head."
+        uses: actions/checkout@v4
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: "Pull request: Build"
+        if: ${{ github.event_name == 'pull_request' }}
+        working-directory: ./tests
+        run: docker compose build php${{ matrix.php }}
 
       - name: "Run PhpBench."
         working-directory: ./tests

--- a/.github/workflows/bechmark.yml
+++ b/.github/workflows/bechmark.yml
@@ -41,10 +41,35 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check if we need to create a baseline for a PR
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.ref }}" != "refs/heads/${{ github.event.repository.default_branch }}" ]]; then
+            echo "WITH_BENCH_BASELINE=1" >> $GITHUB_ENV
+          else
+            echo "WITH_BENCH_BASELINE=0" >> $GITHUB_ENV
+          fi
+
+      - name: "Baseline creation: Checkout default branch."
+        uses: actions/checkout@v4
+        if: ${{ env.WITH_BENCH_BASELINE == '1' }}
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
       - name: Build
+        if: ${{ env.WITH_BENCH_BASELINE == '1' }}
         working-directory: ./tests
         run: docker compose build php${{ matrix.php }}
 
+      - name: "Baseline creation: Run PhpBench."
+        if: ${{ env.WITH_BENCH_BASELINE == '1' }}
+        run: docker compose run --rm -e XDEBUG_MODE=off php${{ matrix.php }} php vendor/bin/phpbench run --report='aggregate' --tag=default
+        working-directory: ./tests
+
       - name: "Run PhpBench."
         working-directory: ./tests
-        run: docker compose run --rm -e XDEBUG_MODE=off php${{ matrix.php }} php vendor/bin/phpbench run --report='aggregate' > phpbench.log
+        run: |
+          if [ "${{ env.WITH_BENCH_BASELINE }}" == '1' ]; then
+            docker compose run --rm -e XDEBUG_MODE=off php${{ matrix.php }} php vendor/bin/phpbench run --report='aggregate' --ref=default --assert="mode(variant.time.avg) <= mode(baseline.time.avg) +/- 5%" > phpbench.log
+          else
+            docker compose run --rm -e XDEBUG_MODE=off php${{ matrix.php }} php vendor/bin/phpbench run --report='aggregate' > phpbench.log
+          fi

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -159,14 +159,14 @@ final class Adapter implements AdapterInterface
     }
 
     /**
-     * @psalm-return array{expiration: int, delivery_mode: int}&array
+     * @psalm-return array{expiration: string, delivery_mode: int}&array
      */
     private function getDelayMessageProperties(int $delayMilliseconds): array
     {
         return array_merge(
             $this->queueProvider->getMessageProperties(),
             [
-                'expiration' => $delayMilliseconds,
+                'expiration' => (string) $delayMilliseconds,
                 'delivery_mode' => AMQPMessage::DELIVERY_MODE_PERSISTENT,
             ],
         );

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -5,19 +5,22 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\AMQP;
 
 use BackedEnum;
+use InvalidArgumentException;
+use PhpAmqpLib\Exchange\AMQPExchangeType;
 use PhpAmqpLib\Message\AMQPMessage;
 use Throwable;
 use Yiisoft\Queue\Adapter\AdapterInterface;
 use Yiisoft\Queue\AMQP\Exception\NotImplementedException;
+use Yiisoft\Queue\AMQP\Settings\ExchangeSettingsInterface;
+use Yiisoft\Queue\AMQP\Settings\QueueSettingsInterface;
 use Yiisoft\Queue\Cli\LoopInterface;
-use Yiisoft\Queue\JobStatus;
+use Yiisoft\Queue\Message\DelayEnvelope;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Message\MessageSerializerInterface;
+use Yiisoft\Queue\MessageStatus;
 
 final class Adapter implements AdapterInterface
 {
-    private ?AMQPMessage $amqpMessage = null;
-
     public function __construct(
         private QueueProviderInterface $queueProvider,
         private readonly MessageSerializerInterface $serializer,
@@ -31,7 +34,6 @@ final class Adapter implements AdapterInterface
 
         $channelName = is_string($channel) ? $channel : (string) $channel->value;
         $instance->queueProvider = $this->queueProvider->withChannelName($channelName);
-        $instance->amqpMessage = null;
 
         return $instance;
     }
@@ -47,29 +49,30 @@ final class Adapter implements AdapterInterface
     /**
      * @return never
      */
-    public function status(int|string $id): JobStatus
+    public function status(int|string $id): MessageStatus
     {
         throw new NotImplementedException('Status check is not supported by the adapter ' . self::class . '.');
     }
 
     public function push(MessageInterface $message): MessageInterface
     {
-        $this->amqpMessage ??= new AMQPMessage(
+        $queueProvider = $this->getQueueProviderForMessage($message);
+
+        $amqpMessage = new AMQPMessage(
             '',
-            $this->queueProvider->getMessageProperties(),
+            $queueProvider->getMessageProperties(),
         );
-        $amqpMessage = $this->amqpMessage;
 
         $payload = $this->serializer->serialize($message);
         $amqpMessage->setBody($payload);
-        $exchangeSettings = $this->queueProvider->getExchangeSettings();
+        $exchangeSettings = $queueProvider->getExchangeSettings();
 
-        $this->queueProvider
+        $queueProvider
             ->getChannel()
             ->basic_publish(
                 $amqpMessage,
                 $exchangeSettings?->getName() ?? '',
-                $exchangeSettings ? '' : $this->queueProvider
+                $exchangeSettings ? '' : $queueProvider
                     ->getQueueSettings()
                     ->getName()
             );
@@ -127,5 +130,70 @@ final class Adapter implements AdapterInterface
     public function getChannel(): string
     {
         return $this->queueProvider->getQueueSettings()->getName();
+    }
+
+    private function getQueueProviderForMessage(MessageInterface $message): QueueProviderInterface
+    {
+        $delaySeconds = DelayEnvelope::fromMessage($message)->getDelaySeconds();
+        if ($delaySeconds <= 0) {
+            return $this->queueProvider;
+        }
+
+        $exchangeSettings = $this->queueProvider->getExchangeSettings();
+        if ($exchangeSettings === null) {
+            throw new InvalidArgumentException('Message cannot be delayed to a queue without an exchange. Exchange is mandatory.');
+        }
+
+        return $this->queueProvider
+            ->withMessageProperties($this->getDelayMessageProperties($delaySeconds))
+            ->withExchangeSettings($this->getDelayExchangeSettings($exchangeSettings))
+            ->withQueueSettings(
+                $this->getDelayQueueSettings(
+                    $this->queueProvider->getQueueSettings(),
+                    $exchangeSettings,
+                    $delaySeconds,
+                )
+            );
+    }
+
+    /**
+     * @psalm-return array{expiration: int|float, delivery_mode: int}&array
+     */
+    private function getDelayMessageProperties(float $delaySeconds): array
+    {
+        return array_merge(
+            $this->queueProvider->getMessageProperties(),
+            [
+                'expiration' => $delaySeconds * 1000,
+                'delivery_mode' => AMQPMessage::DELIVERY_MODE_PERSISTENT,
+            ],
+        );
+    }
+
+    private function getDelayQueueSettings(
+        QueueSettingsInterface $queueSettings,
+        ExchangeSettingsInterface $exchangeSettings,
+        float $delaySeconds,
+    ): QueueSettingsInterface {
+        $deliveryTime = time() + $delaySeconds;
+
+        return $queueSettings
+            ->withName("{$queueSettings->getName()}.dlx.$deliveryTime")
+            ->withAutoDeletable(true)
+            ->withArguments(
+                [
+                    'x-dead-letter-exchange' => ['S', $exchangeSettings->getName()],
+                    'x-expires' => ['I', $delaySeconds * 1000 + 30000],
+                    'x-message-ttl' => ['I', $delaySeconds * 1000],
+                ]
+            );
+    }
+
+    private function getDelayExchangeSettings(ExchangeSettingsInterface $exchangeSettings): ExchangeSettingsInterface
+    {
+        return $exchangeSettings
+            ->withName("{$exchangeSettings->getName()}.dlx")
+            ->withAutoDelete(true)
+            ->withType(AMQPExchangeType::TOPIC);
     }
 }

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -32,8 +32,8 @@ final class Adapter implements AdapterInterface
     {
         $instance = clone $this;
 
-        $channelName = is_string($channel) ? $channel : (string) $channel->value;
-        $instance->queueProvider = $this->queueProvider->withChannelName($channelName);
+        $queueName = is_string($channel) ? $channel : (string) $channel->value;
+        $instance->queueProvider = $this->queueProvider->withQueueName($queueName);
 
         return $instance;
     }
@@ -144,27 +144,29 @@ final class Adapter implements AdapterInterface
             throw new InvalidArgumentException('Message cannot be delayed to a queue without an exchange. Exchange is mandatory.');
         }
 
+        $delayMilliseconds = (int) ceil($delaySeconds * 1000);
+
         return $this->queueProvider
-            ->withMessageProperties($this->getDelayMessageProperties($delaySeconds))
+            ->withMessageProperties($this->getDelayMessageProperties($delayMilliseconds))
             ->withExchangeSettings($this->getDelayExchangeSettings($exchangeSettings))
             ->withQueueSettings(
                 $this->getDelayQueueSettings(
                     $this->queueProvider->getQueueSettings(),
                     $exchangeSettings,
-                    $delaySeconds,
+                    $delayMilliseconds,
                 )
             );
     }
 
     /**
-     * @psalm-return array{expiration: int|float, delivery_mode: int}&array
+     * @psalm-return array{expiration: int, delivery_mode: int}&array
      */
-    private function getDelayMessageProperties(float $delaySeconds): array
+    private function getDelayMessageProperties(int $delayMilliseconds): array
     {
         return array_merge(
             $this->queueProvider->getMessageProperties(),
             [
-                'expiration' => $delaySeconds * 1000,
+                'expiration' => $delayMilliseconds,
                 'delivery_mode' => AMQPMessage::DELIVERY_MODE_PERSISTENT,
             ],
         );
@@ -173,9 +175,9 @@ final class Adapter implements AdapterInterface
     private function getDelayQueueSettings(
         QueueSettingsInterface $queueSettings,
         ExchangeSettingsInterface $exchangeSettings,
-        float $delaySeconds,
+        int $delayMilliseconds,
     ): QueueSettingsInterface {
-        $deliveryTime = time() + $delaySeconds;
+        $deliveryTime = time() + (int) ceil($delayMilliseconds / 1000);
 
         return $queueSettings
             ->withName("{$queueSettings->getName()}.dlx.$deliveryTime")
@@ -183,8 +185,8 @@ final class Adapter implements AdapterInterface
             ->withArguments(
                 [
                     'x-dead-letter-exchange' => ['S', $exchangeSettings->getName()],
-                    'x-expires' => ['I', $delaySeconds * 1000 + 30000],
-                    'x-message-ttl' => ['I', $delaySeconds * 1000],
+                    'x-expires' => ['I', $delayMilliseconds + 30000],
+                    'x-message-ttl' => ['I', $delayMilliseconds],
                 ]
             );
     }

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -83,6 +83,17 @@ final class Adapter implements AdapterInterface
     public function subscribe(callable $handlerCallback): void
     {
         $channel = $this->queueProvider->getChannel();
+        $qosSettings = $this->queueProvider
+            ->getQueueSettings()
+            ->getQosSettings();
+        if ($qosSettings !== null) {
+            $channel->basic_qos(
+                $qosSettings->getPrefetchSize(),
+                $qosSettings->getPrefetchCount(),
+                $qosSettings->isGlobal(),
+            );
+        }
+
         $channel->basic_consume(
             $this->queueProvider
                 ->getQueueSettings()

--- a/src/Exception/ExchangeDeclaredException.php
+++ b/src/Exception/ExchangeDeclaredException.php
@@ -17,16 +17,16 @@ final class ExchangeDeclaredException extends InvalidArgumentException implement
     public function getSolution(): ?string
     {
         return <<<'SOLUTION'
-            Can't explicitly set channel name when an exchange is declared.
+            Can't explicitly set queue name when an exchange is declared.
 
             Probably, you have called QueueFactory::get() without explicit configuration
-            for a given channel.
+            for a given queue.
             Your QueueProvider configuration has an exchange,
             which can't be implicitly binded to a new queue due to differences in behaviors
             of different types of exchanges. Please, create an explicit configuration
-            with a fully-configured adapter for the channel you are trying to create.
+            with a fully-configured adapter for the queue you are trying to create.
 
-            Reference: https://github.com/yiisoft/yii-queue#different-queue-channels
+            Reference: https://github.com/yiisoft/queue/blob/master/docs/guide/en/queue-names.md
 
             SOLUTION;
     }

--- a/src/Middleware/DelayMiddleware.php
+++ b/src/Middleware/DelayMiddleware.php
@@ -35,6 +35,10 @@ final class DelayMiddleware implements PushMiddlewareInterface
 
     public function processPush(MessageInterface $message, PushHandlerInterface $handler): MessageInterface
     {
+        if ($this->delayInSeconds <= 0) {
+            return $handler->handlePush($message);
+        }
+
         return $handler->handlePush(new DelayEnvelope($message, $this->delayInSeconds));
     }
 }

--- a/src/Middleware/DelayMiddleware.php
+++ b/src/Middleware/DelayMiddleware.php
@@ -4,20 +4,14 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\AMQP\Middleware;
 
-use InvalidArgumentException;
-use PhpAmqpLib\Exchange\AMQPExchangeType;
-use PhpAmqpLib\Message\AMQPMessage;
-use Yiisoft\Queue\AMQP\Adapter;
-use Yiisoft\Queue\AMQP\QueueProviderInterface;
-use Yiisoft\Queue\AMQP\Settings\ExchangeSettingsInterface;
-use Yiisoft\Queue\AMQP\Settings\QueueSettingsInterface;
-use Yiisoft\Queue\Middleware\Push\Implementation\DelayMiddlewareInterface;
-use Yiisoft\Queue\Middleware\Push\MessageHandlerPushInterface;
-use Yiisoft\Queue\Middleware\Push\PushRequest;
+use Yiisoft\Queue\Message\DelayEnvelope;
+use Yiisoft\Queue\Message\MessageInterface;
+use Yiisoft\Queue\Middleware\Push\PushHandlerInterface;
+use Yiisoft\Queue\Middleware\Push\PushMiddlewareInterface;
 
-final class DelayMiddleware implements DelayMiddlewareInterface
+final class DelayMiddleware implements PushMiddlewareInterface
 {
-    public function __construct(private float $delayInSeconds, private readonly bool $forcePersistentMessages = true)
+    public function __construct(private float $delayInSeconds)
     {
     }
 
@@ -39,76 +33,8 @@ final class DelayMiddleware implements DelayMiddlewareInterface
         return $this->delayInSeconds;
     }
 
-    public function processPush(PushRequest $request, MessageHandlerPushInterface $handler): PushRequest
+    public function processPush(MessageInterface $message, PushHandlerInterface $handler): MessageInterface
     {
-        $adapter = $request->getAdapter();
-        if (!$adapter instanceof Adapter) {
-            $type = get_debug_type($adapter);
-            $class = Adapter::class;
-            throw new InvalidArgumentException(
-                "This middleware works only with the $class. $type given."
-            );
-        }
-
-        if ($adapter->getQueueProvider()->getExchangeSettings() === null) {
-            throw new InvalidArgumentException('Message cannot be delayed to a queue without an exchange. Exchange is mandatory.');
-        }
-
-        $queueProvider = $adapter->getQueueProvider();
-        $exchangeSettings = $this->getExchangeSettings($queueProvider->getExchangeSettings());
-        $queueSettings = $this->getQueueSettings($queueProvider->getQueueSettings(), $queueProvider->getExchangeSettings());
-        $adapter = $adapter->withQueueProvider(
-            $queueProvider
-                ->withMessageProperties($this->getMessageProperties($queueProvider))
-                ->withExchangeSettings($exchangeSettings)
-                ->withQueueSettings($queueSettings)
-        );
-
-        return $handler->handlePush($request->withAdapter($adapter));
-    }
-
-    /**
-     * @psalm-return array{expiration: int|float, delivery_mode?: int}&array
-     */
-    private function getMessageProperties(QueueProviderInterface $queueProvider): array
-    {
-        $messageProperties = ['expiration' => $this->delayInSeconds * 1000];
-        if ($this->forcePersistentMessages === true) {
-            $messageProperties['delivery_mode'] = AMQPMessage::DELIVERY_MODE_PERSISTENT;
-        }
-
-        return array_merge($queueProvider->getMessageProperties(), $messageProperties);
-    }
-
-    private function getQueueSettings(
-        QueueSettingsInterface $queueSettings,
-        ?ExchangeSettingsInterface $exchangeSettings
-    ): QueueSettingsInterface {
-        $deliveryTime = time() + $this->delayInSeconds;
-
-        return $queueSettings
-            ->withName("{$queueSettings->getName()}.dlx.$deliveryTime")
-            ->withAutoDeletable(true)
-            ->withArguments(
-                [
-                    'x-dead-letter-exchange' => ['S', $exchangeSettings?->getName() ?? ''],
-                    'x-expires' => ['I', $this->delayInSeconds * 1000 + 30000],
-                    'x-message-ttl' => ['I', $this->delayInSeconds * 1000],
-                ]
-            );
-    }
-
-    /**
-     * @see https://github.com/vimeo/psalm/issues/9454
-     *
-     * @psalm-suppress LessSpecificReturnType
-     */
-    private function getExchangeSettings(?ExchangeSettingsInterface $exchangeSettings): ?ExchangeSettingsInterface
-    {
-        /** @noinspection NullPointerExceptionInspection */
-        return $exchangeSettings
-            ?->withName("{$exchangeSettings->getName()}.dlx")
-            ->withAutoDelete(true)
-            ->withType(AMQPExchangeType::TOPIC);
+        return $handler->handlePush(new DelayEnvelope($message, $this->delayInSeconds));
     }
 }

--- a/src/QueueProvider.php
+++ b/src/QueueProvider.php
@@ -50,7 +50,7 @@ final class QueueProvider implements QueueProviderInterface
         }
 
         $this->channelId = $this->connection->get_free_channel_id();
-        $channel = $this->connection->channel($this->getChannelId());
+        $channel = $this->connection->channel($this->channelId);
         $channel->queue_declare(...$this->queueSettings->getPositionalSettings());
 
         if ($this->exchangeSettings !== null) {
@@ -88,9 +88,6 @@ final class QueueProvider implements QueueProviderInterface
 
         $instance = clone $this;
         $instance->queueSettings = $instance->queueSettings->withName($queue);
-        if ($this->channelId !== null) {
-            $instance->channelId = null;
-        }
 
         return $instance;
     }
@@ -134,14 +131,5 @@ final class QueueProvider implements QueueProviderInterface
             $this->connection->channel($this->channelId)->close();
             $this->channelId = null;
         }
-    }
-
-    private function getChannelId(): int
-    {
-        if ($this->channelId === null) {
-            $this->channelId = $this->connection->get_free_channel_id();
-        }
-
-        return $this->channelId;
     }
 }

--- a/src/QueueProvider.php
+++ b/src/QueueProvider.php
@@ -76,9 +76,9 @@ final class QueueProvider implements QueueProviderInterface
         return $this->messageProperties;
     }
 
-    public function withChannelName(string $channel): self
+    public function withQueueName(string $queue): self
     {
-        if ($channel === $this->queueSettings->getName()) {
+        if ($queue === $this->queueSettings->getName()) {
             return $this;
         }
 
@@ -87,7 +87,7 @@ final class QueueProvider implements QueueProviderInterface
         }
 
         $instance = clone $this;
-        $instance->queueSettings = $instance->queueSettings->withName($channel);
+        $instance->queueSettings = $instance->queueSettings->withName($queue);
         if ($this->channelId !== null) {
             $instance->channelId = null;
         }

--- a/src/QueueProviderInterface.php
+++ b/src/QueueProviderInterface.php
@@ -21,7 +21,7 @@ interface QueueProviderInterface
 
     public function getMessageProperties(): array;
 
-    public function withChannelName(string $channel): self;
+    public function withQueueName(string $queue): self;
 
     public function withQueueSettings(QueueSettingsInterface $queueSettings): self;
 

--- a/src/Settings/QosSettings.php
+++ b/src/Settings/QosSettings.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Queue\AMQP\Settings;
+
+use InvalidArgumentException;
+
+/**
+ * Quality of Service settings for AMQP consumers.
+ *
+ * @see \PhpAmqpLib\Channel\AMQPChannel::basic_qos()
+ */
+final class QosSettings
+{
+    public function __construct(
+        private readonly int $prefetchSize = 0,
+        private readonly int $prefetchCount = 0,
+        private readonly bool $global = false,
+    ) {
+        if ($prefetchSize < 0) {
+            throw new InvalidArgumentException('Prefetch size must be a non-negative integer.');
+        }
+
+        if ($prefetchCount < 0) {
+            throw new InvalidArgumentException('Prefetch count must be a non-negative integer.');
+        }
+    }
+
+    public function getPrefetchSize(): int
+    {
+        return $this->prefetchSize;
+    }
+
+    public function getPrefetchCount(): int
+    {
+        return $this->prefetchCount;
+    }
+
+    public function isGlobal(): bool
+    {
+        return $this->global;
+    }
+}

--- a/src/Settings/Queue.php
+++ b/src/Settings/Queue.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\AMQP\Settings;
 
 use PhpAmqpLib\Wire\AMQPTable;
-use Yiisoft\Queue\QueueInterface;
+use Yiisoft\Queue\Provider\QueueProviderInterface;
 
 final class Queue implements QueueSettingsInterface
 {
     public function __construct(
-        private string $queueName = QueueInterface::DEFAULT_CHANNEL,
+        private string $queueName = QueueProviderInterface::DEFAULT_QUEUE,
         private bool $passive = false,
         private bool $durable = true,
         private bool $exclusive = false,

--- a/src/Settings/Queue.php
+++ b/src/Settings/Queue.php
@@ -17,7 +17,8 @@ final class Queue implements QueueSettingsInterface
         private bool $autoDelete = false,
         private bool $nowait = false,
         private AMQPTable|array $arguments = [],
-        private ?int $ticket = null
+        private ?int $ticket = null,
+        private ?QosSettings $qosSettings = null,
     ) {
     }
 
@@ -34,6 +35,11 @@ final class Queue implements QueueSettingsInterface
     public function getTicket(): ?int
     {
         return $this->ticket;
+    }
+
+    public function getQosSettings(): ?QosSettings
+    {
+        return $this->qosSettings;
     }
 
     public function isAutoDeletable(): bool
@@ -100,6 +106,14 @@ final class Queue implements QueueSettingsInterface
     {
         $new = clone $this;
         $new->ticket = $ticket;
+
+        return $new;
+    }
+
+    public function withQosSettings(?QosSettings $qosSettings): self
+    {
+        $new = clone $this;
+        $new->qosSettings = $qosSettings;
 
         return $new;
     }

--- a/src/Settings/QueueSettingsInterface.php
+++ b/src/Settings/QueueSettingsInterface.php
@@ -14,6 +14,8 @@ interface QueueSettingsInterface
 
     public function getTicket(): ?int;
 
+    public function getQosSettings(): ?QosSettings;
+
     public function isAutoDeletable(): bool;
 
     public function isDurable(): bool;
@@ -40,6 +42,8 @@ interface QueueSettingsInterface
     public function withName(string $name): self;
 
     public function withTicket(?int $ticket): self;
+
+    public function withQosSettings(?QosSettings $qosSettings): self;
 
     public function withAutoDeletable(bool $autoDeletable): self;
 

--- a/tests/Benchmark/QueueConsumeBench.php
+++ b/tests/Benchmark/QueueConsumeBench.php
@@ -14,7 +14,7 @@ use Yiisoft\Queue\AMQP\QueueProvider;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\Cli\SimpleLoop;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\GenericMessage as Message;
 
 #[BeforeClassMethods('cleanupQueue')]
 final class QueueConsumeBench

--- a/tests/Benchmark/QueueConsumeBench.php
+++ b/tests/Benchmark/QueueConsumeBench.php
@@ -14,7 +14,7 @@ use Yiisoft\Queue\AMQP\QueueProvider;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\Cli\SimpleLoop;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\AMQP\Tests\Support\TestMessage as Message;
 
 #[BeforeClassMethods('cleanupQueue')]
 final class QueueConsumeBench
@@ -42,7 +42,7 @@ final class QueueConsumeBench
     public function pushMessagesForConsume(): void
     {
         for ($i = 0; $i < self::MESSAGE_COUNT; $i++) {
-            $this->adapter->push(new Message('test', ['payload' => 'test']));
+            $this->adapter->push(Message::fromData('test', ['payload' => 'test']));
         }
     }
 

--- a/tests/Benchmark/QueueConsumeBench.php
+++ b/tests/Benchmark/QueueConsumeBench.php
@@ -14,7 +14,7 @@ use Yiisoft\Queue\AMQP\QueueProvider;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\Cli\SimpleLoop;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\GenericMessage as Message;
+use Yiisoft\Queue\Message\Message;
 
 #[BeforeClassMethods('cleanupQueue')]
 final class QueueConsumeBench

--- a/tests/Benchmark/QueuePushBench.php
+++ b/tests/Benchmark/QueuePushBench.php
@@ -16,7 +16,7 @@ use Yiisoft\Queue\AMQP\QueueProvider;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\Cli\SimpleLoop;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\AMQP\Tests\Support\TestMessage as Message;
 
 final class QueuePushBench
 {
@@ -53,7 +53,7 @@ final class QueuePushBench
     #[OutputTimeUnit('seconds')]
     public function benchPush(): void
     {
-        $this->adapter->push(new Message('test', ['payload' => 'test']));
+        $this->adapter->push(Message::fromData('test', ['payload' => 'test']));
     }
 
     /**
@@ -67,7 +67,7 @@ final class QueuePushBench
     #[OutputTimeUnit('seconds')]
     public function benchPushBatch(): void
     {
-        $message = new Message('test', ['payload' => 'test']);
+        $message = Message::fromData('test', ['payload' => 'test']);
         for ($i = 0; $i < 100; $i++) {
             $this->adapter->push($message);
         }

--- a/tests/Benchmark/QueuePushBench.php
+++ b/tests/Benchmark/QueuePushBench.php
@@ -16,7 +16,7 @@ use Yiisoft\Queue\AMQP\QueueProvider;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\Cli\SimpleLoop;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\GenericMessage as Message;
+use Yiisoft\Queue\Message\Message;
 
 final class QueuePushBench
 {

--- a/tests/Benchmark/QueuePushBench.php
+++ b/tests/Benchmark/QueuePushBench.php
@@ -16,7 +16,7 @@ use Yiisoft\Queue\AMQP\QueueProvider;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\Cli\SimpleLoop;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\GenericMessage as Message;
 
 final class QueuePushBench
 {

--- a/tests/Integration/ConsumeExistingMessagesTest.php
+++ b/tests/Integration/ConsumeExistingMessagesTest.php
@@ -9,7 +9,7 @@ use Yiisoft\Queue\AMQP\QueueProvider;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\Cli\SimpleLoop;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\GenericMessage as Message;
+use Yiisoft\Queue\Message\Message;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 class ConsumeExistingMessagesTest extends TestCase

--- a/tests/Integration/ConsumeExistingMessagesTest.php
+++ b/tests/Integration/ConsumeExistingMessagesTest.php
@@ -9,7 +9,7 @@ use Yiisoft\Queue\AMQP\QueueProvider;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\Cli\SimpleLoop;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\GenericMessage as Message;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 class ConsumeExistingMessagesTest extends TestCase

--- a/tests/Integration/ConsumeExistingMessagesTest.php
+++ b/tests/Integration/ConsumeExistingMessagesTest.php
@@ -9,7 +9,7 @@ use Yiisoft\Queue\AMQP\QueueProvider;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\Cli\SimpleLoop;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\AMQP\Tests\Support\TestMessage as Message;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 class ConsumeExistingMessagesTest extends TestCase
@@ -31,7 +31,7 @@ class ConsumeExistingMessagesTest extends TestCase
 
         $messageCount = 10;
         for ($i = 0; $i < $messageCount; $i++) {
-            $adapter->push(new Message('test', ['payload' => 'test']));
+            $adapter->push(Message::fromData('test', ['payload' => 'test']));
         }
 
         // wait for messages to be ready to consume
@@ -63,7 +63,7 @@ class ConsumeExistingMessagesTest extends TestCase
 
         $messageCount = 10;
         for ($i = 0; $i < $messageCount; $i++) {
-            $adapter->push(new Message('test', ['payload' => 'test']));
+            $adapter->push(Message::fromData('test', ['payload' => 'test']));
         }
 
         // wait for messages to be ready to consume

--- a/tests/Integration/DelayMiddlewareTest.php
+++ b/tests/Integration/DelayMiddlewareTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\AMQP\Tests\Integration;
 
-use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Yiisoft\Queue\Adapter\AdapterInterface;
@@ -18,10 +17,10 @@ use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
 use Yiisoft\Queue\Cli\LoopInterface;
 use Yiisoft\Queue\Cli\SignalLoop;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\GenericMessage as Message;
 use Yiisoft\Queue\Middleware\CallableFactory;
-use Yiisoft\Queue\Middleware\Push\MiddlewareFactoryPush;
-use Yiisoft\Queue\Middleware\Push\PushMiddlewareDispatcher;
+use Yiisoft\Queue\Middleware\Push\PushMiddlewareConfig;
+use Yiisoft\Queue\Middleware\Push\PushMiddlewareFactory;
 use Yiisoft\Queue\Queue;
 use Yiisoft\Queue\Worker\WorkerInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
@@ -48,12 +47,11 @@ final class DelayMiddlewareTest extends TestCase
             new JsonMessageSerializer(),
             new SignalLoop(),
         );
-        $queue = $this->makeQueue($adapter);
+        $queue = $this->makeQueue($adapter)->withMiddlewaresAdded(new DelayMiddleware(3));
 
         $time = time();
         $queue->push(
             new Message('simple', 'test-delay-middleware-main'),
-            new DelayMiddleware(3),
         );
 
         sleep(2);
@@ -68,9 +66,6 @@ final class DelayMiddlewareTest extends TestCase
 
     public function testMainFlowWithFakeAdapter(): void
     {
-        $adapterClass = Adapter::class;
-        $fakeAdapterClass = FakeAdapter::class;
-
         $adapter = new FakeAdapter(
             new QueueProvider(
                 $this->createConnection(),
@@ -80,13 +75,12 @@ final class DelayMiddlewareTest extends TestCase
             new JsonMessageSerializer(),
             new SignalLoop(),
         );
-        $queue = $this->makeQueue($adapter);
+        $queue = $this->makeQueue($adapter)->withMiddlewaresAdded(new DelayMiddleware(3));
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("This middleware works only with the $adapterClass. $fakeAdapterClass given.");
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Method not implemented');
         $queue->push(
             new Message('simple', 'test-delay-middleware-main'),
-            new DelayMiddleware(3),
         );
     }
 
@@ -96,8 +90,8 @@ final class DelayMiddlewareTest extends TestCase
             $this->createMock(WorkerInterface::class),
             $this->createMock(LoopInterface::class),
             $this->createMock(LoggerInterface::class),
-            new PushMiddlewareDispatcher(
-                new MiddlewareFactoryPush(
+            new PushMiddlewareConfig(
+                new PushMiddlewareFactory(
                     new SimpleContainer(),
                     new CallableFactory($this->createMock(ContainerInterface::class)),
                 ),

--- a/tests/Integration/DelayMiddlewareTest.php
+++ b/tests/Integration/DelayMiddlewareTest.php
@@ -17,7 +17,7 @@ use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
 use Yiisoft\Queue\Cli\LoopInterface;
 use Yiisoft\Queue\Cli\SignalLoop;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\AMQP\Tests\Support\TestMessage as Message;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Push\PushMiddlewareConfig;
 use Yiisoft\Queue\Middleware\Push\PushMiddlewareFactory;
@@ -51,7 +51,7 @@ final class DelayMiddlewareTest extends TestCase
 
         $time = time();
         $queue->push(
-            new Message('simple', 'test-delay-middleware-main'),
+            Message::fromData('simple', 'test-delay-middleware-main'),
         );
 
         sleep(2);
@@ -80,7 +80,7 @@ final class DelayMiddlewareTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Method not implemented');
         $queue->push(
-            new Message('simple', 'test-delay-middleware-main'),
+            Message::fromData('simple', 'test-delay-middleware-main'),
         );
     }
 

--- a/tests/Integration/DelayMiddlewareTest.php
+++ b/tests/Integration/DelayMiddlewareTest.php
@@ -17,7 +17,7 @@ use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
 use Yiisoft\Queue\Cli\LoopInterface;
 use Yiisoft\Queue\Cli\SignalLoop;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\GenericMessage as Message;
+use Yiisoft\Queue\Message\Message;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Push\PushMiddlewareConfig;
 use Yiisoft\Queue\Middleware\Push\PushMiddlewareFactory;

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -43,7 +43,7 @@ abstract class TestCase extends MainTestCase
         // TODO Fail test on subprocess error exit code
         $command = [PHP_BINARY, dirname(__DIR__) . '/yii', 'queue:listen'];
         if ($queue !== null) {
-            $command[] = "--channel=$queue";
+            $command[] = $queue;
         }
         $process = new Process($command);
         $this->processes[] = $process;

--- a/tests/Support/FakeAdapter.php
+++ b/tests/Support/FakeAdapter.php
@@ -9,9 +9,9 @@ use LogicException;
 use Yiisoft\Queue\Adapter\AdapterInterface;
 use Yiisoft\Queue\AMQP\QueueProviderInterface;
 use Yiisoft\Queue\Cli\LoopInterface;
-use Yiisoft\Queue\JobStatus;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Message\MessageSerializerInterface;
+use Yiisoft\Queue\MessageStatus;
 
 final class FakeAdapter implements AdapterInterface
 {
@@ -27,7 +27,7 @@ final class FakeAdapter implements AdapterInterface
         throw new LogicException('Method not implemented');
     }
 
-    public function status(int|string $id): JobStatus
+    public function status(int|string $id): MessageStatus
     {
         throw new LogicException('Method not implemented');
     }

--- a/tests/Support/TestMessage.php
+++ b/tests/Support/TestMessage.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Queue\AMQP\Tests\Support;
+
+use Yiisoft\Queue\Message\MessageInterface;
+
+final class TestMessage implements MessageInterface
+{
+    public function __construct(
+        private readonly string $type,
+        private readonly mixed $data,
+        private readonly array $metadata = [],
+    ) {
+    }
+
+    public static function fromData(string $type, mixed $data, array $metadata = []): self
+    {
+        return new self($type, $data, $metadata);
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getData(): mixed
+    {
+        return $this->data;
+    }
+
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+
+    public function withMetadata(array $metadata): self
+    {
+        return new self($this->type, $this->data, $metadata);
+    }
+}

--- a/tests/Support/TestMessage.php
+++ b/tests/Support/TestMessage.php
@@ -35,7 +35,7 @@ final class TestMessage implements MessageInterface
         return $this->metadata;
     }
 
-    public function withMetadata(array $metadata): self
+    public function withMetadata(array $metadata): static
     {
         return new self($this->type, $this->data, $metadata);
     }

--- a/tests/Unit/DelayMiddlewareTest.php
+++ b/tests/Unit/DelayMiddlewareTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
 use Yiisoft\Queue\AMQP\Middleware\DelayMiddleware;
 use Yiisoft\Queue\Message\DelayEnvelope;
-use Yiisoft\Queue\Message\GenericMessage as Message;
+use Yiisoft\Queue\Message\Message;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\Push\PushHandlerInterface;
 

--- a/tests/Unit/DelayMiddlewareTest.php
+++ b/tests/Unit/DelayMiddlewareTest.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
 use Yiisoft\Queue\AMQP\Middleware\DelayMiddleware;
+use Yiisoft\Queue\Message\DelayEnvelope;
+use Yiisoft\Queue\Message\GenericMessage as Message;
+use Yiisoft\Queue\Message\MessageInterface;
+use Yiisoft\Queue\Middleware\Push\PushHandlerInterface;
 
 final class DelayMiddlewareTest extends UnitTestCase
 {
@@ -23,5 +27,36 @@ final class DelayMiddlewareTest extends UnitTestCase
         $delayMiddleware = new DelayMiddleware(0);
 
         self::assertNotSame($delayMiddleware, $delayMiddleware->withDelay(1));
+    }
+
+    public function testProcessPushAddsDelayEnvelope(): void
+    {
+        $message = new Message('simple', null);
+        $handler = new class () implements PushHandlerInterface {
+            public function handlePush(MessageInterface $message): MessageInterface
+            {
+                return $message;
+            }
+        };
+
+        $result = (new DelayMiddleware(1.5))->processPush($message, $handler);
+
+        self::assertNotSame($message, $result);
+        self::assertSame(1.5, DelayEnvelope::fromMessage($result)->getDelaySeconds());
+    }
+
+    public function testProcessPushSkipsNonPositiveDelay(): void
+    {
+        $message = new Message('simple', null);
+        $handler = new class () implements PushHandlerInterface {
+            public function handlePush(MessageInterface $message): MessageInterface
+            {
+                return $message;
+            }
+        };
+
+        $result = (new DelayMiddleware(0))->processPush($message, $handler);
+
+        self::assertSame($message, $result);
     }
 }

--- a/tests/Unit/DelayMiddlewareTest.php
+++ b/tests/Unit/DelayMiddlewareTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
 use Yiisoft\Queue\AMQP\Middleware\DelayMiddleware;
 use Yiisoft\Queue\Message\DelayEnvelope;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\AMQP\Tests\Support\TestMessage as Message;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\Push\PushHandlerInterface;
 
@@ -31,7 +31,7 @@ final class DelayMiddlewareTest extends UnitTestCase
 
     public function testProcessPushAddsDelayEnvelope(): void
     {
-        $message = new Message('simple', null);
+        $message = Message::fromData('simple', null);
         $handler = new class () implements PushHandlerInterface {
             public function handlePush(MessageInterface $message): MessageInterface
             {
@@ -47,7 +47,7 @@ final class DelayMiddlewareTest extends UnitTestCase
 
     public function testProcessPushSkipsNonPositiveDelay(): void
     {
-        $message = new Message('simple', null);
+        $message = Message::fromData('simple', null);
         $handler = new class () implements PushHandlerInterface {
             public function handlePush(MessageInterface $message): MessageInterface
             {

--- a/tests/Unit/ExchangeSettingsTest.php
+++ b/tests/Unit/ExchangeSettingsTest.php
@@ -6,42 +6,23 @@ namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
 use PhpAmqpLib\Exchange\AMQPExchangeType;
 use PhpAmqpLib\Wire\AMQPTable;
-use Yiisoft\Queue\AMQP\Adapter;
-use Yiisoft\Queue\AMQP\QueueProvider;
 use Yiisoft\Queue\AMQP\Settings\Exchange as ExchangeSettings;
-use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
-use Yiisoft\Queue\Message\JsonMessageSerializer;
 
 final class ExchangeSettingsTest extends UnitTestCase
 {
     public function testCommonSettings(): void
     {
-        $queueProvider = new QueueProvider(
-            $this->createConnection(),
-            $this->getQueueSettings(),
+        $exchangeSettings = new ExchangeSettings(
+            exchangeName: 'yii-queue-test-common-settings',
+            passive: true,
+            durable: true,
+            autoDelete: false,
+            internal: true,
+            nowait: true,
+            arguments: new AMQPTable([
+                'alternate-exchange' => 'yii-queue-test-common-settings-alt',
+            ])
         );
-        $adapter = new Adapter(
-            $queueProvider
-                ->withQueueSettings(
-                    new QueueSettings('yii-queue-test-common-settings')
-                )
-                ->withExchangeSettings(
-                    new ExchangeSettings(
-                        exchangeName: 'yii-queue-test-common-settings',
-                        passive: true,
-                        durable: true,
-                        autoDelete: false,
-                        internal: true,
-                        nowait: true,
-                        arguments: new AMQPTable([
-                            'alternate-exchange' => 'yii-queue-test-common-settings-alt',
-                        ])
-                    )
-                ),
-            new JsonMessageSerializer(),
-            $this->getLoop(),
-        );
-        $exchangeSettings = $adapter->getQueueProvider()->getExchangeSettings();
 
         self::assertTrue($exchangeSettings->isDurable());
         self::assertTrue($exchangeSettings->isInternal());

--- a/tests/Unit/QosSettingsTest.php
+++ b/tests/Unit/QosSettingsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Queue\AMQP\Tests\Unit;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Queue\AMQP\Settings\QosSettings;
+
+final class QosSettingsTest extends TestCase
+{
+    public function testDefaultValues(): void
+    {
+        $settings = new QosSettings();
+
+        self::assertSame(0, $settings->getPrefetchSize());
+        self::assertSame(0, $settings->getPrefetchCount());
+        self::assertFalse($settings->isGlobal());
+    }
+
+    public function testValues(): void
+    {
+        $settings = new QosSettings(
+            prefetchSize: 1024,
+            prefetchCount: 10,
+            global: true,
+        );
+
+        self::assertSame(1024, $settings->getPrefetchSize());
+        self::assertSame(10, $settings->getPrefetchCount());
+        self::assertTrue($settings->isGlobal());
+    }
+
+    public function testNegativePrefetchSize(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Prefetch size must be a non-negative integer.');
+
+        new QosSettings(prefetchSize: -1);
+    }
+
+    public function testNegativePrefetchCount(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Prefetch count must be a non-negative integer.');
+
+        new QosSettings(prefetchCount: -1);
+    }
+}

--- a/tests/Unit/QueueProviderTest.php
+++ b/tests/Unit/QueueProviderTest.php
@@ -13,7 +13,7 @@ use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\AMQP\Settings\QueueSettingsInterface;
 use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\GenericMessage as Message;
+use Yiisoft\Queue\Message\Message;
 
 final class QueueProviderTest extends UnitTestCase
 {

--- a/tests/Unit/QueueProviderTest.php
+++ b/tests/Unit/QueueProviderTest.php
@@ -13,7 +13,7 @@ use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\AMQP\Settings\QueueSettingsInterface;
 use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\GenericMessage as Message;
 
 final class QueueProviderTest extends UnitTestCase
 {
@@ -38,7 +38,7 @@ final class QueueProviderTest extends UnitTestCase
             $this->getLoop(),
         );
 
-        $queue = $this->getQueue()->withAdapter($adapter);
+        $queue = $this->getQueueWithAdapter($adapter);
 
         $fileHelper = new FileHelper();
         $time = time();

--- a/tests/Unit/QueueProviderTest.php
+++ b/tests/Unit/QueueProviderTest.php
@@ -13,7 +13,7 @@ use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\AMQP\Settings\QueueSettingsInterface;
 use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\AMQP\Tests\Support\TestMessage as Message;
 
 final class QueueProviderTest extends UnitTestCase
 {
@@ -43,7 +43,7 @@ final class QueueProviderTest extends UnitTestCase
         $fileHelper = new FileHelper();
         $time = time();
         $queue->push(
-            new Message('ext-simple', ['file_name' => 'test-with-queue-settings', 'payload' => ['time' => $time]])
+            Message::fromData('ext-simple', ['file_name' => 'test-with-queue-settings', 'payload' => ['time' => $time]])
         );
 
         $message = $this

--- a/tests/Unit/QueueProviderTest.php
+++ b/tests/Unit/QueueProviderTest.php
@@ -64,7 +64,7 @@ final class QueueProviderTest extends UnitTestCase
         self::assertEquals($messageBody['data']['payload']['time'], $result);
     }
 
-    public function testWithChannelNameExchangeDeclaredException(): void
+    public function testWithQueueNameExchangeDeclaredException(): void
     {
         $queueProvider = new QueueProvider(
             $this->createConnection(),
@@ -75,12 +75,12 @@ final class QueueProviderTest extends UnitTestCase
         new Adapter(
             $queueProvider
                 ->withQueueSettings(
-                    new QueueSettings('yii-queue-test-with-channel-name')
+                    new QueueSettings('yii-queue-test-with-queue-name')
                 )
                 ->withExchangeSettings(
-                    new ExchangeSettings('yii-queue-test-with-channel-name')
+                    new ExchangeSettings('yii-queue-test-with-queue-name')
                 )
-                ->withChannelName('yii-queue-test-channel-name'),
+                ->withQueueName('yii-queue-test-queue-name'),
             new JsonMessageSerializer(),
             $this->getLoop(),
         );

--- a/tests/Unit/QueueSettingsTest.php
+++ b/tests/Unit/QueueSettingsTest.php
@@ -12,7 +12,7 @@ use Yiisoft\Queue\AMQP\Settings\Exchange as ExchangeSettings;
 use Yiisoft\Queue\AMQP\Settings\QosSettings;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\GenericMessage as Message;
+use Yiisoft\Queue\Message\Message;
 
 final class QueueSettingsTest extends UnitTestCase
 {

--- a/tests/Unit/QueueSettingsTest.php
+++ b/tests/Unit/QueueSettingsTest.php
@@ -9,6 +9,7 @@ use PhpAmqpLib\Wire\AMQPTable;
 use Yiisoft\Queue\AMQP\Adapter;
 use Yiisoft\Queue\AMQP\QueueProvider;
 use Yiisoft\Queue\AMQP\Settings\Exchange as ExchangeSettings;
+use Yiisoft\Queue\AMQP\Settings\QosSettings;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
 use Yiisoft\Queue\Message\GenericMessage as Message;
@@ -40,34 +41,18 @@ final class QueueSettingsTest extends UnitTestCase
 
     public function testCommonSettings(): void
     {
-        $queueProvider = new QueueProvider(
-            $this->createConnection(),
-            $this->getQueueSettings(),
+        $queueSettings = new QueueSettings(
+            queueName: 'yii-queue-test-queue-common-settings',
+            passive: true,
+            durable: true,
+            exclusive: true,
+            nowait: true,
+            arguments: new AMQPTable([
+                'x-dead-letter-exchange' => 'yii-queue-test-queue-common-settings-dead-letter-exc',
+                'x-message-ttl' => 15000,
+                'x-expires' => 16000,
+            ])
         );
-        $adapter = new Adapter(
-            $queueProvider
-                ->withQueueSettings(
-                    new QueueSettings(
-                        queueName: 'yii-queue-test-queue-common-settings',
-                        passive: true,
-                        durable: true,
-                        exclusive: true,
-                        nowait: true,
-                        arguments: new AMQPTable([
-                            'x-dead-letter-exchange' => 'yii-queue-test-queue-common-settings-dead-letter-exc',
-                            'x-message-ttl' => 15000,
-                            'x-expires' => 16000,
-                        ])
-                    )
-                )
-                ->withExchangeSettings(
-                    new ExchangeSettings('yii-queue-test-queue-common-settings')
-                ),
-            new JsonMessageSerializer(),
-            $this->getLoop(),
-        );
-
-        $queueSettings = $adapter->getQueueProvider()->getQueueSettings();
 
         self::assertTrue($queueSettings->isDurable());
         self::assertTrue($queueSettings->isPassive());
@@ -82,6 +67,7 @@ final class QueueSettingsTest extends UnitTestCase
         self::assertFalse($queueSettings->withAutoDeletable(false)->isAutoDeletable());
         self::assertFalse($queueSettings->withNowait(false)->hasNowait());
         self::assertEquals(0, $queueSettings->withTicket(0)->getTicket());
+        self::assertEquals(new QosSettings(prefetchCount: 1), $queueSettings->withQosSettings(new QosSettings(prefetchCount: 1))->getQosSettings());
 
         self::assertInstanceOf(AMQPTable::class, $queueSettings->getArguments());
         self::assertArrayHasKey('x-dead-letter-exchange', $queueSettings->getArguments());
@@ -139,5 +125,6 @@ final class QueueSettingsTest extends UnitTestCase
         self::assertNotSame($queueSettings, $queueSettings->withName('test'));
         self::assertNotSame($queueSettings, $queueSettings->withAutoDeletable(false));
         self::assertNotSame($queueSettings, $queueSettings->withArguments([]));
+        self::assertNotSame($queueSettings, $queueSettings->withQosSettings(new QosSettings(prefetchCount: 1)));
     }
 }

--- a/tests/Unit/QueueSettingsTest.php
+++ b/tests/Unit/QueueSettingsTest.php
@@ -11,7 +11,7 @@ use Yiisoft\Queue\AMQP\QueueProvider;
 use Yiisoft\Queue\AMQP\Settings\Exchange as ExchangeSettings;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\GenericMessage as Message;
 
 final class QueueSettingsTest extends UnitTestCase
 {
@@ -89,8 +89,7 @@ final class QueueSettingsTest extends UnitTestCase
             $this->getLoop(),
         );
 
-        $this->getQueue()
-            ->withAdapter($adapter)
+        $this->getQueueWithAdapter($adapter)
             ->push(
                 new Message('ext-simple', ['payload' => time()])
             );

--- a/tests/Unit/QueueSettingsTest.php
+++ b/tests/Unit/QueueSettingsTest.php
@@ -15,6 +15,29 @@ use Yiisoft\Queue\Message\GenericMessage as Message;
 
 final class QueueSettingsTest extends UnitTestCase
 {
+    private const TEST_QUEUE_NAMES = [
+        'yii-queue-test-queue-settings-arg',
+        'yii-queue-test-queue-common-settings',
+    ];
+
+    protected function setUp(): void
+    {
+        $savedQueueName = $this->queueName;
+        $savedExchangeName = $this->exchangeName;
+
+        foreach (self::TEST_QUEUE_NAMES as $name) {
+            $this->queueName = $name;
+            $this->exchangeName = $name;
+            $this->deleteQueue();
+            $this->deleteExchange();
+        }
+
+        $this->queueName = $savedQueueName;
+        $this->exchangeName = $savedExchangeName;
+
+        parent::setUp();
+    }
+
     public function testCommonSettings(): void
     {
         $queueProvider = new QueueProvider(
@@ -68,6 +91,9 @@ final class QueueSettingsTest extends UnitTestCase
 
     public function testArgumentsXExpires(): void
     {
+        $this->queueName = 'yii-queue-test-queue-settings-arg';
+        $this->exchangeName = 'yii-queue-test-queue-settings-arg';
+
         $queueProvider = new QueueProvider(
             $this->createConnection(),
             $this->getQueueSettings(),

--- a/tests/Unit/QueueSettingsTest.php
+++ b/tests/Unit/QueueSettingsTest.php
@@ -12,7 +12,7 @@ use Yiisoft\Queue\AMQP\Settings\Exchange as ExchangeSettings;
 use Yiisoft\Queue\AMQP\Settings\QosSettings;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\AMQP\Tests\Support\TestMessage as Message;
 
 final class QueueSettingsTest extends UnitTestCase
 {
@@ -103,7 +103,7 @@ final class QueueSettingsTest extends UnitTestCase
 
         $this->getQueueWithAdapter($adapter)
             ->push(
-                new Message('ext-simple', ['payload' => time()])
+                Message::fromData('ext-simple', ['payload' => time()])
             );
 
         sleep(2);

--- a/tests/Unit/QueueTest.php
+++ b/tests/Unit/QueueTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
 use Exception;
+use PhpAmqpLib\Message\AMQPMessage;
 use Yiisoft\Queue\Adapter\AdapterInterface;
 use Yiisoft\Queue\AMQP\Adapter;
 use Yiisoft\Queue\AMQP\Exception\NotImplementedException;
@@ -140,5 +141,28 @@ final class QueueTest extends UnitTestCase
 
         self::assertNotSame($adapter, $adapter->withChannel('test'));
         self::assertNotSame($adapter, $adapter->withQueueProvider($queueProvider));
+    }
+
+    public function testDelayMessagePropertiesUseStringExpiration(): void
+    {
+        $queueProvider = $this->createMock(QueueProviderInterface::class);
+        $queueProvider
+            ->method('getMessageProperties')
+            ->willReturn([]);
+
+        $adapter = new Adapter(
+            $queueProvider,
+            $this->createMock(MessageSerializerInterface::class),
+            $this->createMock(LoopInterface::class)
+        );
+        $method = new \ReflectionMethod($adapter, 'getDelayMessageProperties');
+
+        self::assertSame(
+            [
+                'expiration' => '1500',
+                'delivery_mode' => AMQPMessage::DELIVERY_MODE_PERSISTENT,
+            ],
+            $method->invoke($adapter, 1500)
+        );
     }
 }

--- a/tests/Unit/QueueTest.php
+++ b/tests/Unit/QueueTest.php
@@ -112,7 +112,7 @@ final class QueueTest extends UnitTestCase
         );
         $adapter = new Adapter(
             $queueProvider
-                ->withChannelName('yii-queue'),
+                ->withQueueName('yii-queue'),
             new JsonMessageSerializer(),
             $mockLoop,
         );

--- a/tests/Unit/QueueTest.php
+++ b/tests/Unit/QueueTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
 use Exception;
 use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Exchange\AMQPExchangeType;
 use PhpAmqpLib\Message\AMQPMessage;
 use Yiisoft\Queue\Adapter\AdapterInterface;
 use Yiisoft\Queue\AMQP\Adapter;
@@ -13,15 +14,17 @@ use Yiisoft\Queue\AMQP\Exception\NotImplementedException;
 use Yiisoft\Queue\AMQP\QueueProvider;
 use Yiisoft\Queue\AMQP\QueueProviderInterface;
 use Yiisoft\Queue\AMQP\Settings\Exchange as ExchangeSettings;
+use Yiisoft\Queue\AMQP\Settings\ExchangeSettingsInterface;
 use Yiisoft\Queue\AMQP\Settings\QosSettings;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\AMQP\Settings\QueueSettingsInterface;
 use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
 use Yiisoft\Queue\Cli\LoopInterface;
 use Yiisoft\Queue\Exception\MessageFailureException;
+use Yiisoft\Queue\Message\DelayEnvelope;
 use Yiisoft\Queue\Message\IdEnvelope;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\GenericMessage as Message;
+use Yiisoft\Queue\Message\Message;
 use Yiisoft\Queue\Message\MessageSerializerInterface;
 use Yiisoft\Queue\Queue;
 
@@ -146,27 +149,102 @@ final class QueueTest extends UnitTestCase
         self::assertNotSame($adapter, $adapter->withQueueProvider($queueProvider));
     }
 
-    public function testDelayMessagePropertiesUseStringExpiration(): void
+    public function testPushUsesStringExpirationForDelayedMessage(): void
     {
+        $message = new DelayEnvelope(new Message('ext-simple', null), 1.5);
+        $exchangeSettings = new ExchangeSettings('test-exchange');
+        $queueSettings = new QueueSettings('test-queue');
+        $delayMessageProperties = [
+            'expiration' => '1500',
+            'delivery_mode' => AMQPMessage::DELIVERY_MODE_PERSISTENT,
+        ];
+
+        $channel = $this->createMock(AMQPChannel::class);
+        $channel
+            ->expects(self::once())
+            ->method('basic_publish')
+            ->with(
+                self::callback(static function (AMQPMessage $amqpMessage): bool {
+                    self::assertSame('1500', $amqpMessage->get('expiration'));
+                    self::assertSame(AMQPMessage::DELIVERY_MODE_PERSISTENT, $amqpMessage->get('delivery_mode'));
+                    self::assertSame('payload', $amqpMessage->getBody());
+
+                    return true;
+                }),
+                'test-exchange.dlx',
+                '',
+            );
+
+        $delayedQueueProvider = $this->createMock(QueueProviderInterface::class);
+        $delayedQueueProvider
+            ->method('getMessageProperties')
+            ->willReturn($delayMessageProperties);
+        $delayedQueueProvider
+            ->expects(self::once())
+            ->method('withExchangeSettings')
+            ->with(self::callback(static function (ExchangeSettingsInterface $settings): bool {
+                self::assertSame('test-exchange.dlx', $settings->getName());
+                self::assertSame(AMQPExchangeType::TOPIC, $settings->getType());
+                self::assertTrue($settings->isAutoDelete());
+
+                return true;
+            }))
+            ->willReturnSelf();
+        $delayedQueueProvider
+            ->expects(self::once())
+            ->method('withQueueSettings')
+            ->with(self::callback(static function (QueueSettingsInterface $settings): bool {
+                self::assertMatchesRegularExpression('/^test-queue\.dlx\.\d+$/', $settings->getName());
+                self::assertTrue($settings->isAutoDeletable());
+                self::assertSame(
+                    [
+                        'x-dead-letter-exchange' => ['S', 'test-exchange'],
+                        'x-expires' => ['I', 31500],
+                        'x-message-ttl' => ['I', 1500],
+                    ],
+                    $settings->getArguments(),
+                );
+
+                return true;
+            }))
+            ->willReturnSelf();
+        $delayedQueueProvider
+            ->method('getChannel')
+            ->willReturn($channel);
+        $delayedQueueProvider
+            ->method('getExchangeSettings')
+            ->willReturn(new ExchangeSettings('test-exchange.dlx'));
+
         $queueProvider = $this->createMock(QueueProviderInterface::class);
         $queueProvider
             ->method('getMessageProperties')
             ->willReturn([]);
+        $queueProvider
+            ->method('getExchangeSettings')
+            ->willReturn($exchangeSettings);
+        $queueProvider
+            ->method('getQueueSettings')
+            ->willReturn($queueSettings);
+        $queueProvider
+            ->expects(self::once())
+            ->method('withMessageProperties')
+            ->with($delayMessageProperties)
+            ->willReturn($delayedQueueProvider);
+
+        $serializer = $this->createMock(MessageSerializerInterface::class);
+        $serializer
+            ->expects(self::once())
+            ->method('serialize')
+            ->with($message)
+            ->willReturn('payload');
 
         $adapter = new Adapter(
             $queueProvider,
-            $this->createMock(MessageSerializerInterface::class),
+            $serializer,
             $this->createMock(LoopInterface::class)
         );
-        $method = new \ReflectionMethod($adapter, 'getDelayMessageProperties');
 
-        self::assertSame(
-            [
-                'expiration' => '1500',
-                'delivery_mode' => AMQPMessage::DELIVERY_MODE_PERSISTENT,
-            ],
-            $method->invoke($adapter, 1500)
-        );
+        self::assertSame($message, $adapter->push($message));
     }
 
     public function testSubscribeUsesConfiguredBasicQos(): void

--- a/tests/Unit/QueueTest.php
+++ b/tests/Unit/QueueTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\AMQP\Tests\Unit;
 
 use Exception;
+use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Message\AMQPMessage;
 use Yiisoft\Queue\Adapter\AdapterInterface;
 use Yiisoft\Queue\AMQP\Adapter;
@@ -12,7 +13,9 @@ use Yiisoft\Queue\AMQP\Exception\NotImplementedException;
 use Yiisoft\Queue\AMQP\QueueProvider;
 use Yiisoft\Queue\AMQP\QueueProviderInterface;
 use Yiisoft\Queue\AMQP\Settings\Exchange as ExchangeSettings;
+use Yiisoft\Queue\AMQP\Settings\QosSettings;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
+use Yiisoft\Queue\AMQP\Settings\QueueSettingsInterface;
 use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
 use Yiisoft\Queue\Cli\LoopInterface;
 use Yiisoft\Queue\Exception\MessageFailureException;
@@ -164,5 +167,53 @@ final class QueueTest extends UnitTestCase
             ],
             $method->invoke($adapter, 1500)
         );
+    }
+
+    public function testSubscribeUsesConfiguredBasicQos(): void
+    {
+        $queueSettings = $this->createMock(QueueSettingsInterface::class);
+        $queueSettings->method('getQosSettings')->willReturn(new QosSettings(1024, 10, true));
+        $queueSettings->method('getName')->willReturn('test-queue');
+
+        $channel = $this->createMock(AMQPChannel::class);
+        $channel->expects(self::once())
+            ->method('basic_qos')
+            ->with(1024, 10, true);
+        $channel->expects(self::once())
+            ->method('basic_consume')
+            ->with('test-queue', 'test-queue', false, false, false, true, self::anything());
+
+        $queueProvider = $this->createMock(QueueProviderInterface::class);
+        $queueProvider->method('getChannel')->willReturn($channel);
+        $queueProvider->method('getQueueSettings')->willReturn($queueSettings);
+
+        $loop = $this->createMock(LoopInterface::class);
+        $loop->method('canContinue')->willReturn(false);
+
+        $adapter = new Adapter($queueProvider, $this->createMock(MessageSerializerInterface::class), $loop);
+        $adapter->subscribe(static fn() => null);
+    }
+
+    public function testSubscribeSkipsBasicQosWhenNotConfigured(): void
+    {
+        $queueSettings = $this->createMock(QueueSettingsInterface::class);
+        $queueSettings->method('getQosSettings')->willReturn(null);
+        $queueSettings->method('getName')->willReturn('test-queue');
+
+        $channel = $this->createMock(AMQPChannel::class);
+        $channel->expects(self::never())->method('basic_qos');
+        $channel->expects(self::once())
+            ->method('basic_consume')
+            ->with('test-queue', 'test-queue', false, false, false, true, self::anything());
+
+        $queueProvider = $this->createMock(QueueProviderInterface::class);
+        $queueProvider->method('getChannel')->willReturn($channel);
+        $queueProvider->method('getQueueSettings')->willReturn($queueSettings);
+
+        $loop = $this->createMock(LoopInterface::class);
+        $loop->method('canContinue')->willReturn(false);
+
+        $adapter = new Adapter($queueProvider, $this->createMock(MessageSerializerInterface::class), $loop);
+        $adapter->subscribe(static fn() => null);
     }
 }

--- a/tests/Unit/QueueTest.php
+++ b/tests/Unit/QueueTest.php
@@ -14,10 +14,10 @@ use Yiisoft\Queue\AMQP\Settings\Exchange as ExchangeSettings;
 use Yiisoft\Queue\AMQP\Settings\Queue as QueueSettings;
 use Yiisoft\Queue\AMQP\Tests\Support\FileHelper;
 use Yiisoft\Queue\Cli\LoopInterface;
-use Yiisoft\Queue\Exception\JobFailureException;
+use Yiisoft\Queue\Exception\MessageFailureException;
 use Yiisoft\Queue\Message\IdEnvelope;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\GenericMessage as Message;
 use Yiisoft\Queue\Message\MessageSerializerInterface;
 use Yiisoft\Queue\Queue;
 
@@ -93,7 +93,7 @@ final class QueueTest extends UnitTestCase
         $time = time();
         $queue->push(new Message('exception-listen', ['payload' => ['time' => $time]]));
 
-        $this->expectException(JobFailureException::class);
+        $this->expectException(MessageFailureException::class);
 
         $queue->listen();
 
@@ -126,9 +126,7 @@ final class QueueTest extends UnitTestCase
 
     private function getDefaultQueue(AdapterInterface $adapter): Queue
     {
-        return $this
-            ->getQueue()
-            ->withAdapter($adapter);
+        return $this->getQueueWithAdapter($adapter);
     }
 
     public function testImmutable(): void

--- a/tests/Unit/QueueTest.php
+++ b/tests/Unit/QueueTest.php
@@ -24,7 +24,7 @@ use Yiisoft\Queue\Exception\MessageFailureException;
 use Yiisoft\Queue\Message\DelayEnvelope;
 use Yiisoft\Queue\Message\IdEnvelope;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\AMQP\Tests\Support\TestMessage as Message;
 use Yiisoft\Queue\Message\MessageSerializerInterface;
 use Yiisoft\Queue\Queue;
 
@@ -42,7 +42,7 @@ final class QueueTest extends UnitTestCase
 
         $queue = $this->getDefaultQueue($adapter);
 
-        $message = new Message('ext-simple', null);
+        $message = Message::fromData('ext-simple', null);
         $queue->push(
             $message,
         );
@@ -67,7 +67,7 @@ final class QueueTest extends UnitTestCase
         $queue = $this->getDefaultQueue($this->getAdapter());
 
         $queue->push(
-            new Message('ext-simple', ['file_name' => $fileName, 'payload' => ['time' => $time]])
+            Message::fromData('ext-simple', ['file_name' => $fileName, 'payload' => ['time' => $time]])
         );
 
         self::assertNull($fileHelper->get($fileName));
@@ -98,7 +98,7 @@ final class QueueTest extends UnitTestCase
         $queue = $this->getDefaultQueue($adapter);
 
         $time = time();
-        $queue->push(new Message('exception-listen', ['payload' => ['time' => $time]]));
+        $queue->push(Message::fromData('exception-listen', ['payload' => ['time' => $time]]));
 
         $this->expectException(MessageFailureException::class);
 
@@ -126,7 +126,7 @@ final class QueueTest extends UnitTestCase
         $queue = $this->getDefaultQueue($adapter);
 
         $queue->push(
-            new Message('ext-simple', ['file_name' => 'test-listen' . $time, 'payload' => ['time' => $time]])
+            Message::fromData('ext-simple', ['file_name' => 'test-listen' . $time, 'payload' => ['time' => $time]])
         );
         $queue->listen();
     }
@@ -151,7 +151,7 @@ final class QueueTest extends UnitTestCase
 
     public function testPushUsesStringExpirationForDelayedMessage(): void
     {
-        $message = new DelayEnvelope(new Message('ext-simple', null), 1.5);
+        $message = new DelayEnvelope(Message::fromData('ext-simple', null), 1.5);
         $exchangeSettings = new ExchangeSettings('test-exchange');
         $queueSettings = new QueueSettings('test-queue');
         $delayMessageProperties = [

--- a/tests/Unit/UnitTestCase.php
+++ b/tests/Unit/UnitTestCase.php
@@ -21,11 +21,11 @@ use Yiisoft\Queue\Message\JsonMessageSerializer;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareDispatcher;
-use Yiisoft\Queue\Middleware\Consume\MiddlewareFactoryConsume;
+use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareFactory;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureMiddlewareDispatcher;
-use Yiisoft\Queue\Middleware\FailureHandling\MiddlewareFactoryFailure;
-use Yiisoft\Queue\Middleware\Push\MiddlewareFactoryPush;
-use Yiisoft\Queue\Middleware\Push\PushMiddlewareDispatcher;
+use Yiisoft\Queue\Middleware\FailureHandling\FailureMiddlewareFactory;
+use Yiisoft\Queue\Middleware\Push\PushMiddlewareConfig;
+use Yiisoft\Queue\Middleware\Push\PushMiddlewareFactory;
 use Yiisoft\Queue\Queue;
 use Yiisoft\Queue\Worker\Worker;
 use Yiisoft\Queue\Worker\WorkerInterface;
@@ -70,7 +70,18 @@ abstract class UnitTestCase extends MainTestCase
             $this->getWorker(),
             $this->getLoop(),
             new NullLogger(),
-            $this->getPushMiddlewareDispatcher()
+            $this->getPushMiddlewareConfig(),
+        );
+    }
+
+    protected function getQueueWithAdapter(AdapterInterface $adapter): Queue
+    {
+        return new Queue(
+            $this->getWorker(),
+            $this->getLoop(),
+            new NullLogger(),
+            $this->getPushMiddlewareConfig(),
+            $adapter,
         );
     }
 
@@ -83,6 +94,7 @@ abstract class UnitTestCase extends MainTestCase
             $this->getContainer(),
             $this->getConsumeMiddlewareDispatcher(),
             $this->getFailureMiddlewareDispatcher(),
+            new CallableFactory($this->getContainer()),
         );
     }
 
@@ -112,7 +124,7 @@ abstract class UnitTestCase extends MainTestCase
     protected function getConsumeMiddlewareDispatcher(): ConsumeMiddlewareDispatcher
     {
         return new ConsumeMiddlewareDispatcher(
-            new MiddlewareFactoryConsume(
+            new ConsumeMiddlewareFactory(
                 $this->getContainer(),
                 new CallableFactory($this->getContainer()),
             ),
@@ -122,7 +134,7 @@ abstract class UnitTestCase extends MainTestCase
     protected function getFailureMiddlewareDispatcher(): FailureMiddlewareDispatcher
     {
         return new FailureMiddlewareDispatcher(
-            new MiddlewareFactoryFailure(
+            new FailureMiddlewareFactory(
                 $this->getContainer(),
                 new CallableFactory($this->getContainer()),
             ),
@@ -144,10 +156,10 @@ abstract class UnitTestCase extends MainTestCase
         return $this->loop ??= new SignalLoop();
     }
 
-    protected function getPushMiddlewareDispatcher(): PushMiddlewareDispatcher
+    protected function getPushMiddlewareConfig(): PushMiddlewareConfig
     {
-        return new PushMiddlewareDispatcher(
-            new MiddlewareFactoryPush(
+        return new PushMiddlewareConfig(
+            new PushMiddlewareFactory(
                 $this->getContainer(),
                 new CallableFactory($this->getContainer()),
             ),

--- a/tests/yii
+++ b/tests/yii
@@ -17,14 +17,14 @@ use Yiisoft\Queue\Command\RunCommand;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareDispatcher;
-use Yiisoft\Queue\Middleware\Consume\MiddlewareFactoryConsume;
+use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareFactory;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureMiddlewareDispatcher;
-use Yiisoft\Queue\Middleware\FailureHandling\MiddlewareFactoryFailure;
-use Yiisoft\Queue\Middleware\Push\MiddlewareFactoryPush;
-use Yiisoft\Queue\Middleware\Push\PushMiddlewareDispatcher;
-use Yiisoft\Queue\Provider\PrototypeQueueProvider;
+use Yiisoft\Queue\Middleware\FailureHandling\FailureMiddlewareFactory;
+use Yiisoft\Queue\Middleware\Push\PushMiddlewareConfig;
+use Yiisoft\Queue\Middleware\Push\PushMiddlewareFactory;
+use Yiisoft\Queue\Provider\PredefinedQueueProvider;
 use Yiisoft\Queue\Queue;
-use Yiisoft\Queue\QueueInterface;
+use Yiisoft\Queue\Provider\QueueProviderInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
@@ -40,11 +40,12 @@ $worker = new \Yiisoft\Queue\Worker\Worker(
     $logger,
     $injector,
     $container,
-    new ConsumeMiddlewareDispatcher(new MiddlewareFactoryConsume($container, $callableFactory)),
-    new FailureMiddlewareDispatcher(new MiddlewareFactoryFailure($container, $callableFactory), []),
+    new ConsumeMiddlewareDispatcher(new ConsumeMiddlewareFactory($container, $callableFactory)),
+    new FailureMiddlewareDispatcher(new FailureMiddlewareFactory($container, $callableFactory), []),
+    $callableFactory,
 );
 $loop = new SignalLoop();
-$pushMiddlewareDispatcher = new PushMiddlewareDispatcher(new MiddlewareFactoryPush($container, $callableFactory));
+$pushMiddlewareConfig = new PushMiddlewareConfig(new PushMiddlewareFactory($container, $callableFactory));
 $adapter = new Adapter(
     new QueueProvider(
         new AMQPStreamConnection(
@@ -53,7 +54,7 @@ $adapter = new Adapter(
             getenv('RABBITMQ_USER'),
             getenv('RABBITMQ_PASSWORD'),
         ),
-        new QueueSettings(queueName: QueueInterface::DEFAULT_CHANNEL),
+        new QueueSettings(queueName: QueueProviderInterface::DEFAULT_QUEUE),
         new ExchangeSettings(exchangeName: QueueProvider::EXCHANGE_NAME_DEFAULT),
     ),
     new JsonMessageSerializer(),
@@ -63,16 +64,13 @@ $queue = new Queue(
     $worker,
     $loop,
     $logger,
-    $pushMiddlewareDispatcher,
+    $pushMiddlewareConfig,
     $adapter,
 );
-$queueFactory = new PrototypeQueueProvider(
-    $queue,
-    $adapter,
-);
+$queueFactory = new PredefinedQueueProvider([QueueProviderInterface::DEFAULT_QUEUE => $queue]);
 
 $application = new Application();
 $application->add(new ListenCommand($queueFactory));
-$application->add(new RunCommand($queueFactory, []));
+$application->add(new RunCommand($queueFactory));
 
 $application->run();


### PR DESCRIPTION
- align status types, queue defaults, message/test helpers, and middleware factory names with the current `yiisoft/queue` core
- adapt AMQP delay middleware to the current push middleware pipeline by using `DelayEnvelope` metadata
- translate delay metadata in the AMQP adapter when publishing delayed messages
- normalize AMQP delayed-message TTL and expiration values to integer milliseconds
- use string AMQP expiration values for delayed messages
- skip delay envelope wrapping for non-positive middleware delays
- rename the internal queue provider API from channel naming to queue naming
- update queue CLI test helpers to use the current positional queue-name argument
- add cleanup for queue settings tests to avoid leftover AMQP queues/exchanges between runs
- add optional AMQP QoS settings and apply `basic_qos` before consuming messages
- simplify queue provider channel-id handling and remove redundant settings-test adapter setup
- keep benchmark runs on the PR head and skip baseline comparison when the base branch baseline cannot be created
