### PR TITLE
Add `hasStatusSupport()` to `Adapter`

### DIFF
--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -10,7 +10,6 @@ use PhpAmqpLib\Exchange\AMQPExchangeType;
 use PhpAmqpLib\Message\AMQPMessage;
 use Throwable;
 use Yiisoft\Queue\Adapter\AdapterInterface;
-use Yiisoft\Queue\Amqp\Exception\NotImplementedException;
 use Yiisoft\Queue\Amqp\Settings\ExchangeSettingsInterface;
 use Yiisoft\Queue\Amqp\Settings\QueueSettingsInterface;
 use Yiisoft\Queue\Cli\LoopInterface;
@@ -46,12 +45,14 @@ final class Adapter implements AdapterInterface
         (new ExistingMessagesConsumer($this->queueProvider, $this->serializer))->consume($handlerCallback);
     }
 
-    /**
-     * @return never
-     */
     public function status(int|string $id): MessageStatus
     {
-        throw new NotImplementedException('Status check is not supported by the adapter ' . self::class . '.');
+        return MessageStatus::NOT_FOUND;
+    }
+
+    public function hasStatusSupport(): bool
+    {
+        return false;
     }
 
     public function push(MessageInterface $message): MessageInterface

--- a/tests/Support/FakeAdapter.php
+++ b/tests/Support/FakeAdapter.php
@@ -29,7 +29,12 @@ final class FakeAdapter implements AdapterInterface
 
     public function status(int|string $id): MessageStatus
     {
-        throw new LogicException('Method not implemented');
+        return MessageStatus::NOT_FOUND;
+    }
+
+    public function hasStatusSupport(): bool
+    {
+        return false;
     }
 
     public function push(MessageInterface $message): MessageInterface

--- a/tests/Unit/QueueTest.php
+++ b/tests/Unit/QueueTest.php
@@ -10,7 +10,6 @@ use PhpAmqpLib\Exchange\AMQPExchangeType;
 use PhpAmqpLib\Message\AMQPMessage;
 use Yiisoft\Queue\Adapter\AdapterInterface;
 use Yiisoft\Queue\Amqp\Adapter;
-use Yiisoft\Queue\Amqp\Exception\NotImplementedException;
 use Yiisoft\Queue\Amqp\QueueProvider;
 use Yiisoft\Queue\Amqp\QueueProviderInterface;
 use Yiisoft\Queue\Amqp\Settings\Exchange as ExchangeSettings;
@@ -22,34 +21,34 @@ use Yiisoft\Queue\Amqp\Tests\Support\FileHelper;
 use Yiisoft\Queue\Cli\LoopInterface;
 use Yiisoft\Queue\Exception\MessageFailureException;
 use Yiisoft\Queue\Message\DelayEnvelope;
-use Yiisoft\Queue\Message\IdEnvelope;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
 use Yiisoft\Queue\Amqp\Tests\Support\TestMessage as Message;
 use Yiisoft\Queue\Message\MessageSerializerInterface;
+use Yiisoft\Queue\MessageStatus;
 use Yiisoft\Queue\Queue;
 
 final class QueueTest extends UnitTestCase
 {
-    /**
-     * Testing getting status
-     *
-     * @throws Exception
-     */
     public function testStatus(): void
     {
-        $adapter = $this->getAdapter();
-        $adapterClass = $adapter::class;
-
-        $queue = $this->getDefaultQueue($adapter);
-
-        $message = Message::fromData('ext-simple', null);
-        $queue->push(
-            $message,
+        $adapter = new Adapter(
+            $this->createMock(QueueProviderInterface::class),
+            $this->createMock(MessageSerializerInterface::class),
+            $this->createMock(LoopInterface::class)
         );
 
-        $this->expectException(NotImplementedException::class);
-        $this->expectExceptionMessage("Status check is not supported by the adapter $adapterClass.");
-        $adapter->status(IdEnvelope::fromMessage($message)->getId() ?? '');
+        $this->assertSame(MessageStatus::NOT_FOUND, $adapter->status('any-id'));
+    }
+
+    public function testHasStatusSupport(): void
+    {
+        $adapter = new Adapter(
+            $this->createMock(QueueProviderInterface::class),
+            $this->createMock(MessageSerializerInterface::class),
+            $this->createMock(LoopInterface::class)
+        );
+
+        $this->assertFalse($adapter->hasStatusSupport());
     }
 
     /**

--- a/tests/Unit/QueueTest.php
+++ b/tests/Unit/QueueTest.php
@@ -31,22 +31,14 @@ final class QueueTest extends UnitTestCase
 {
     public function testStatus(): void
     {
-        $adapter = new Adapter(
-            $this->createMock(QueueProviderInterface::class),
-            $this->createMock(MessageSerializerInterface::class),
-            $this->createMock(LoopInterface::class)
-        );
+        $adapter = $this->getAdapter();
 
         $this->assertSame(MessageStatus::NOT_FOUND, $adapter->status('any-id'));
     }
 
     public function testHasStatusSupport(): void
     {
-        $adapter = new Adapter(
-            $this->createMock(QueueProviderInterface::class),
-            $this->createMock(MessageSerializerInterface::class),
-            $this->createMock(LoopInterface::class)
-        );
+        $adapter = $this->getAdapter();
 
         $this->assertFalse($adapter->hasStatusSupport());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Tests added?  | ✔️
| Tests pass?   | ✔️
| Breaks BC?    | ✔️
| Fixed issues  |

## What does this PR do?

Implements `AdapterInterface::hasStatusSupport()` added in yiisoft/queue#299. AMQP has no status tracking, so it returns `false`, and `status()` now returns `MessageStatus::NOT_FOUND` instead of throwing `NotImplementedException` - that is what `AdapterInterface::status()` documents for adapters without status tracking.

Companion PR for yiisoft/queue#299 (issue yiisoft/queue#272); needs that one merged and released first.

### BC

`Adapter::status()` no longer throws `NotImplementedException`; it returns `MessageStatus::NOT_FOUND`. The package is `1.0.0 under development`.
